### PR TITLE
🔒 Fix prototype pollution vulnerability in Terminal cat command

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -178,7 +178,7 @@ export function Terminal() {
       case "cat":
         if (!arg) {
           output = <span className="text-red-500">cat: missing file operand</span>;
-        } else if (files[arg]) {
+        } else if (Object.prototype.hasOwnProperty.call(files, arg)) {
           output = <div className="ml-4 border-l-2 border-border pl-4 my-2">{files[arg]}</div>;
         } else {
           output = <span className="text-red-500">cat: {arg}: No such file or directory</span>;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Prototype Pollution / Invalid File Read vulnerability in the `Terminal` component's `cat` command handling logic.

⚠️ **Risk:** The potential impact if left unfixed includes the application crashing or unexpectedly exposing properties from the `Object` prototype (such as `toString` or `hasOwnProperty`) when the user inputs those keys, bypassing the intended safe file system checks.

🛡️ **Solution:** The fix replaces the direct truthiness index check `if (files[arg])` with `if (Object.prototype.hasOwnProperty.call(files, arg))`. This strict property check ensures that the provided key exists directly on the `files` object and avoids descending into the prototype chain, guaranteeing safety against maliciously crafted input.

---
*PR created automatically by Jules for task [14244510569677705580](https://jules.google.com/task/14244510569677705580) started by @vinersar31*