### PR TITLE
🔒 Security fix: Add rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -26,8 +26,8 @@ const files: Record<string, React.ReactNode> = {
   ),
   "links.txt": (
     <div className="space-y-2">
-      <p>github: <a href="https://github.com/vinersar" target="_blank" className="text-blue-400 hover:underline">github.com/vinersar</a></p>
-      <p>linkedin: <a href="https://linkedin.com/in/vinersar" target="_blank" className="text-blue-400 hover:underline">linkedin.com/in/vinersar</a></p>
+      <p>github: <a href="https://github.com/vinersar" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline">github.com/vinersar</a></p>
+      <p>linkedin: <a href="https://linkedin.com/in/vinersar" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline">linkedin.com/in/vinersar</a></p>
       <p>email: <a href="mailto:vinersar31@example.com" className="text-blue-400 hover:underline">vinersar31@example.com</a></p>
     </div>
   )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was missing `rel="noopener noreferrer"` attributes on `<a>` elements using `target="_blank"` in `src/components/Terminal.tsx`.
⚠️ **Risk:** The potential impact if left unfixed is reverse tabnabbing, where the new tab could manipulate the window.opener object to redirect the original tab to a malicious site or execute unwanted code.
🛡️ **Solution:** The fix adds `rel="noopener noreferrer"` to the affected links, which breaks the connection between the original tab and the new tab, preventing reverse tabnabbing attacks.

---
*PR created automatically by Jules for task [8417811876406886733](https://jules.google.com/task/8417811876406886733) started by @vinersar31*