### PR TITLE
Add building_with_claude_API project to portfolio

### DIFF
--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -39,4 +39,13 @@ describe('Projects Page', () => {
     const mcpLink = links.find(l => l.getAttribute('href') === 'https://github.com/vinersar31/mcp');
     expect(mcpLink).toBeDefined();
   });
+
+  it('has the correct updated url for building_with_claude_API', () => {
+    render(<Projects />);
+
+    // Test specifically for building_with_claude_API URL
+    const links = screen.getAllByRole('link', { name: /view repository/i });
+    const claudeApiLink = links.find(l => l.getAttribute('href') === 'https://github.com/vinersar31/building_with_claude_API');
+    expect(claudeApiLink).toBeDefined();
+  });
 });

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -57,6 +57,12 @@ const projects = [
     url: "https://github.com/vinersar31/istaris",
     isPrivate: false,
   },
+  {
+    title: "Building with Claude API",
+    description: "Simple Jupyter notebooks for learning how to use the Anthropic Claude API with Python.",
+    url: "https://github.com/vinersar31/building_with_claude_API",
+    isPrivate: false,
+  },
 ].map((p) => ({ ...p, title: p.title.toLowerCase(), description: p.description.toLowerCase() }));
 
 export default function Projects() {


### PR DESCRIPTION
Added `building_with_claude_API` repository to the `src/app/projects/page.tsx` portfolio projects array and verified the addition via tests in `src/app/projects/page.test.tsx` and a visual screenshot check.

---
*PR created automatically by Jules for task [9107833018203477061](https://jules.google.com/task/9107833018203477061) started by @vinersar31*