### PR TITLE
feat: improve projects page UI

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,7 +3,7 @@ import { ExternalLink, Lock } from "lucide-react";
 
 export default function Projects() {
   return (
-    <div className="relative min-h-[calc(100vh-80px)] py-12 md:py-24 pt-24">
+    <div className="relative min-h-[calc(100vh-80px)] py-12 md:py-24">
       {/* Background ambient glow effect */}
       <div className="absolute top-1/4 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] bg-primary/5 rounded-full blur-[100px] -z-10 animate-float pointer-events-none" />
 
@@ -16,62 +16,54 @@ export default function Projects() {
           {projects.map((project, index) => (
             <article
               key={project.url}
-              className="group relative flex flex-col justify-between bg-card border border-border rounded-xl transition-all duration-300 hover:shadow-lg dark:hover:shadow-primary/5 hover:-translate-y-1 overflow-hidden animate-fade-in-up"
+              className="group relative flex flex-col justify-between p-6 bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl transition-all duration-500 hover:shadow-2xl hover:shadow-primary/5 hover:border-primary/50 hover:-translate-y-1 overflow-hidden animate-fade-in-up"
               style={{ animationDelay: `${0.2 + index * 0.1}s` }}
             >
-              {/* Terminal Header */}
-              <div className="flex items-center gap-2 px-4 py-3 bg-muted/50 border-b border-border">
-                <div className="flex gap-1.5">
-                  <div className="w-3 h-3 rounded-full bg-[#ff5f56]" />
-                  <div className="w-3 h-3 rounded-full bg-[#ffbd2e]" />
-                  <div className="w-3 h-3 rounded-full bg-[#27c93f]" />
-                </div>
-                <div className="mx-auto flex-1 text-center pr-8">
-                  <span className="text-xs font-mono text-muted-foreground lowercase">
-                    {project.title.replace(/\s+/g, '-').replace(/[^\w-]/g, '')}.sh
-                  </span>
-                </div>
-              </div>
+              {/* Subtle gradient overlay on hover */}
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
 
-              <div className="flex-1 p-6 flex flex-col justify-between">
-                <div className="space-y-4 mb-6">
+              <div className="relative z-10 flex-1 flex flex-col justify-between">
+                <div className="space-y-5 mb-8">
                   <div className="flex items-start justify-between gap-4">
-                    <h3 className="text-xl font-bold leading-tight group-hover:text-primary transition-colors font-mono lowercase">
-                      <span className="text-primary">/</span> {project.title}
+                    <h3 className="text-xl font-bold leading-tight group-hover:text-primary transition-colors duration-300 font-mono lowercase">
+                      <span className="text-primary mr-2 opacity-50 group-hover:opacity-100 transition-opacity">/</span>
+                      {project.title}
                     </h3>
                     {project.badge && (
-                      <span className="shrink-0 text-xs font-mono text-foreground bg-foreground/5 px-2 py-1 rounded-md lowercase">
+                      <span className="shrink-0 text-xs font-mono text-primary-foreground bg-primary/80 backdrop-blur-md px-2.5 py-1 rounded-full lowercase shadow-sm">
                         {project.badge}
                       </span>
                     )}
                   </div>
-                  <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
-                    <span className="text-primary font-mono font-bold mr-2">&gt;</span>
+                  <p className="text-muted-foreground leading-relaxed text-sm md:text-base group-hover:text-foreground/80 transition-colors duration-300">
+                    <span className="text-primary/50 font-mono font-bold mr-2 group-hover:text-primary transition-colors">&gt;</span>
                     {project.description}
                   </p>
                 </div>
 
-                <a
-                  href={project.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-all font-mono lowercase ${
-                    project.isPrivate
-                      ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
-                      : "bg-primary text-primary-foreground hover:bg-primary/90 hover:scale-105"
-                  }`}
-                  title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
-                >
-                  {project.isPrivate ? (
-                    <>
-                      <Lock className="w-4 h-4" /> view repository
-                    </>
-                  ) : (
-                    <>
-                      <ExternalLink className="w-4 h-4" /> view repository
-                    </>
-                  )}
-                </a>
+                <div className="flex items-center">
+                  <a
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl transition-all duration-300 font-mono lowercase ${
+                      project.isPrivate
+                        ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
+                        : "bg-primary/10 text-primary hover:bg-primary hover:text-primary-foreground hover:shadow-lg hover:shadow-primary/20 hover:-translate-y-0.5"
+                    }`}
+                    title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
+                  >
+                    {project.isPrivate ? (
+                      <>
+                        <Lock className="w-4 h-4" /> view repository
+                      </>
+                    ) : (
+                      <>
+                        <ExternalLink className="w-4 h-4" /> view repository
+                      </>
+                    )}
+                  </a>
+                </div>
               </div>
             </article>
           ))}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -2,60 +2,81 @@ import { projects } from "@/data/projects";
 import { ExternalLink, Lock } from "lucide-react";
 
 export default function Projects() {
-
-
   return (
-    <section className="py-12 md:py-24 max-w-5xl mx-auto space-y-12 font-light">
-      <h1 className="text-4xl md:text-5xl font-bold tracking-tight font-mono lowercase">
-        <span className="text-red-500">/</span> projects <span className="text-2xl">🚀</span>
-      </h1>
+    <div className="relative min-h-[calc(100vh-80px)] py-12 md:py-24 pt-24">
+      {/* Background ambient glow effect */}
+      <div className="absolute top-1/4 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] bg-primary/5 rounded-full blur-[100px] -z-10 animate-float pointer-events-none" />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {projects.map((project) => (
-          <article
-            key={project.url}
-            className="group relative flex flex-col justify-between p-6 bg-card border border-border rounded-xl transition-all hover:shadow-lg dark:hover:border-red-500/50"
-          >
-            <div className="space-y-4 mb-6">
-              <div className="flex items-start justify-between gap-4">
-                <h3 className="text-xl font-bold leading-tight group-hover:text-red-500 transition-colors font-mono lowercase">
-                  <span className="text-red-500">/</span> {project.title}
-                </h3>
-                {project.badge && (
-                  <span className="shrink-0 text-[10px] md:text-xs font-medium px-2 py-1 bg-secondary text-secondary-foreground rounded-full lowercase font-mono">
-                    {project.badge}
-                  </span>
-                )}
-              </div>
-              <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
-                {project.description}
-              </p>
-            </div>
+      <section className="max-w-5xl mx-auto space-y-12 font-light px-4 md:px-0">
+        <h1 className="text-4xl md:text-5xl font-bold tracking-tight font-mono lowercase animate-fade-in-up" style={{ animationDelay: '0.1s' }}>
+          <span className="text-primary">/</span> projects <span className="text-2xl">🚀</span>
+        </h1>
 
-            <a
-              href={project.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-colors font-mono lowercase ${
-                project.isPrivate
-                  ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
-                  : "bg-red-500 text-white hover:bg-red-600"
-              }`}
-              title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {projects.map((project, index) => (
+            <article
+              key={project.url}
+              className="group relative flex flex-col justify-between bg-card border border-border rounded-xl transition-all duration-300 hover:shadow-lg dark:hover:shadow-primary/5 hover:-translate-y-1 overflow-hidden animate-fade-in-up"
+              style={{ animationDelay: `${0.2 + index * 0.1}s` }}
             >
-              {project.isPrivate ? (
-                <>
-                  <Lock className="w-4 h-4" /> view repository
-                </>
-              ) : (
-                <>
-                  <ExternalLink className="w-4 h-4" /> view repository
-                </>
-              )}
-            </a>
-          </article>
-        ))}
-      </div>
-    </section>
+              {/* Terminal Header */}
+              <div className="flex items-center gap-2 px-4 py-3 bg-muted/50 border-b border-border">
+                <div className="flex gap-1.5">
+                  <div className="w-3 h-3 rounded-full bg-[#ff5f56]" />
+                  <div className="w-3 h-3 rounded-full bg-[#ffbd2e]" />
+                  <div className="w-3 h-3 rounded-full bg-[#27c93f]" />
+                </div>
+                <div className="mx-auto flex-1 text-center pr-8">
+                  <span className="text-xs font-mono text-muted-foreground lowercase">
+                    {project.title.replace(/\s+/g, '-').replace(/[^\w-]/g, '')}.sh
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex-1 p-6 flex flex-col justify-between">
+                <div className="space-y-4 mb-6">
+                  <div className="flex items-start justify-between gap-4">
+                    <h3 className="text-xl font-bold leading-tight group-hover:text-primary transition-colors font-mono lowercase">
+                      <span className="text-primary">/</span> {project.title}
+                    </h3>
+                    {project.badge && (
+                      <span className="shrink-0 text-xs font-mono text-foreground bg-foreground/5 px-2 py-1 rounded-md lowercase">
+                        {project.badge}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
+                    <span className="text-primary font-mono font-bold mr-2">&gt;</span>
+                    {project.description}
+                  </p>
+                </div>
+
+                <a
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-all font-mono lowercase ${
+                    project.isPrivate
+                      ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
+                      : "bg-primary text-primary-foreground hover:bg-primary/90 hover:scale-105"
+                  }`}
+                  title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
+                >
+                  {project.isPrivate ? (
+                    <>
+                      <Lock className="w-4 h-4" /> view repository
+                    </>
+                  ) : (
+                    <>
+                      <ExternalLink className="w-4 h-4" /> view repository
+                    </>
+                  )}
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
This PR improves the UI of the `/projects` page to align with the "programmer-style" aesthetic used throughout the portfolio.

Changes include:
- Refactoring the project cards into macOS-style terminal windows (adding a top bar with red/yellow/green dots).
- Adding staggered fade-in animations to the project cards for better entry transitions.
- Adding a subtle ambient background glow effect, similar to the main page.
- Refining typography by using `font-mono`, `lowercase`, and styling project badges to look like code tokens.
- Using theme variables (`primary`, `bg-card`, etc.) to ensure proper dark mode support and consistency.

---
*PR created automatically by Jules for task [6665515651628302514](https://jules.google.com/task/6665515651628302514) started by @vinersar31*