### PR TITLE
🔒 Fix prototype pollution / application crash in Terminal cat command

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -76,7 +76,7 @@ const commands: Record<string, (ctx: CommandContext) => CommandResult> = {
   }),
   cat: ({ arg }) => {
     if (!arg) return { output: <span className="text-red-500">cat: missing file operand</span> };
-    if (files[arg]) return { output: <div className="ml-4 border-l-2 border-border pl-4 my-2">{files[arg]}</div> };
+    if (Object.hasOwn(files, arg)) return { output: <div className="ml-4 border-l-2 border-border pl-4 my-2">{files[arg]}</div> };
     return { output: <span className="text-red-500">cat: {arg}: No such file or directory</span> };
   },
   clear: ({ setHistory }) => {

--- a/src/test/components/Terminal.test.tsx
+++ b/src/test/components/Terminal.test.tsx
@@ -40,4 +40,23 @@ describe('Terminal', () => {
         return element?.tagName.toLowerCase() === 'div' && content.includes('Interactive mode activated');
     })).toBeInTheDocument()
   })
+  it('prevents prototype pollution crash on cat toString', () => {
+    render(<Terminal />)
+
+    // Switch to interactive mode
+    const container = screen.getByText(/Welcome to vinersarOS/i).parentElement?.parentElement?.parentElement
+    act(() => {
+      if (container) fireEvent.click(container)
+    })
+
+    // Find the input element and type the command
+    const input = screen.getByRole('textbox')
+    act(() => {
+      fireEvent.change(input, { target: { value: 'cat toString' } })
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+    })
+
+    // The command should successfully run and output the "No such file" error rather than crashing React
+    expect(screen.getByText('cat: toString: No such file or directory')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
🎯 **What:**
The `Terminal` component was vulnerable to Prototype Pollution. Running `cat toString` or using other built-in Object prototype properties (e.g., `constructor`, `valueOf`) would trick the `cat` command logic because `if (files[arg])` evaluates to true for these inherited properties.

⚠️ **Risk:**
When an inherited property like `toString` was passed, `files[arg]` evaluated to a Function instead of a valid string or ReactNode. Attempting to render this function caused React to throw an invariant violation error, leading to a complete white-screen application crash for the user. This effectively allowed a simple Denial of Service (DoS) via user input in the terminal.

🛡️ **Solution:**
Replaced the direct truthy check `if (files[arg])` with `if (Object.hasOwn(files, arg))` to ensure that only properties explicitly defined on the `files` object are evaluated. Also added a comprehensive test case asserting that `cat toString` safely returns an expected error message rather than crashing the application.

---
*PR created automatically by Jules for task [13133978342869157184](https://jules.google.com/task/13133978342869157184) started by @vinersar31*