### PR TITLE
🔒 Fix Prototype Pollution in Terminal Command Execution

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -76,7 +76,7 @@ const commands: Record<string, (ctx: CommandContext) => CommandResult> = {
   }),
   cat: ({ arg }) => {
     if (!arg) return { output: <span className="text-red-500">cat: missing file operand</span> };
-    if (files[arg]) return { output: <div className="ml-4 border-l-2 border-border pl-4 my-2">{files[arg]}</div> };
+    if (Object.hasOwn(files, arg)) return { output: <div className="ml-4 border-l-2 border-border pl-4 my-2">{files[arg]}</div> };
     return { output: <span className="text-red-500">cat: {arg}: No such file or directory</span> };
   },
   clear: ({ setHistory }) => {
@@ -197,7 +197,7 @@ export function Terminal() {
 
     if (!baseCommand) return;
 
-    const handler = commands[baseCommand];
+    const handler = Object.hasOwn(commands, baseCommand) ? commands[baseCommand] : null;
     const result = handler
       ? handler({ arg, router, setHistory })
       : { output: <span className="text-red-500">{baseCommand}: command not found</span> } as CommandResult;


### PR DESCRIPTION
🎯 **What:** Fixed a prototype pollution vulnerability in the Terminal component where unvalidated user input was used to directly access properties on the `commands` and `files` objects.

⚠️ **Risk:** By typing commands matching built-in Object prototype properties (like `__defineGetter__` or `toString`), users could trigger unexpected JavaScript behavior, leading to potential application instability or unexpected side-effects.

🛡️ **Solution:** Swapped direct object indexing (`commands[baseCommand]` and `files[arg]`) with `Object.hasOwn()` checks. This ensures the application only attempts to execute or read explicitly defined commands and files, gracefully falling back to a "command not found" error for prototype properties.

---
*PR created automatically by Jules for task [12885205993455042143](https://jules.google.com/task/12885205993455042143) started by @vinersar31*