### PR TITLE
feat: add capital, vault, sentinel, codex and omnibus to projects list

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -79,4 +79,16 @@ export const projects = [
     url: "https://github.com/vinersar31/omnibus",
     isPrivate: false,
   },
+  {
+    title: "codex",
+    description: "a project named codex.",
+    url: "https://github.com/vinersar31/codex",
+    isPrivate: false,
+  },
+  {
+    title: "sentinel",
+    description: "a project named sentinel.",
+    url: "https://github.com/vinersar31/sentinel",
+    isPrivate: false,
+  },
 ];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -61,4 +61,22 @@ export const projects = [
     url: "https://github.com/vinersar31/building_with_claude_API",
     isPrivate: false,
   },
+  {
+    title: "capital",
+    description: "a project named capital.",
+    url: "https://github.com/vinersar31/capital",
+    isPrivate: false,
+  },
+  {
+    title: "vault",
+    description: "a project named vault.",
+    url: "https://github.com/vinersar31/vault",
+    isPrivate: false,
+  },
+  {
+    title: "omnibus",
+    description: "a project named omnibus.",
+    url: "https://github.com/vinersar31/omnibus",
+    isPrivate: false,
+  },
 ];


### PR DESCRIPTION
This PR adds the capital, vault, and omnibus repositories to the projects tab using their respective GitHub URLs. They are set to public with simple lowercase descriptions to match the site's styling.

---
*PR created automatically by Jules for task [5975866397190645674](https://jules.google.com/task/5975866397190645674) started by @vinersar31*