### PR TITLE
chore: shorten specific project descriptions

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,14 +2,14 @@ export const projects = [
   {
     title: "pulseboard: jira & project metrics",
     badge: "Master's Degree",
-    description: "developed as part of my master's degree in project management. this project collects and visualizes agile-related data from jira, confluence, excel, and manual entries. insights are shown in grafana dashboards powered by prometheus for time-series analytics.",
+    description: "a master's degree project that visualizes agile metrics from jira and other sources using grafana and prometheus.",
     url: "https://github.com/vinersar31/pulse_board",
     isPrivate: true,
   },
   {
     title: "ecommerce mobile app",
     badge: "Bachelor's Degree",
-    description: "created an ecommerce mobile app for my bachelor's degree where users could trade games. built using xamarin forms and c#.",
+    description: "a bachelor's degree project: an ecommerce mobile app for trading games built with xamarin forms and c#.",
     url: "https://github.com/vinersar31/Licenta-Ecommerce",
     isPrivate: true,
   },


### PR DESCRIPTION
Shortened the descriptions for the `pulseboard` and `ecommerce mobile app` projects in `src/data/projects.ts` as requested. Tests pass and UI is unaffected.

---
*PR created automatically by Jules for task [5533959477578184967](https://jules.google.com/task/5533959477578184967) started by @vinersar31*