### PR TITLE
feat: add visit website button to specific projects

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,5 @@
 import { projects } from "@/data/projects";
-import { ExternalLink, Lock } from "lucide-react";
+import { ExternalLink, Lock, Globe } from "lucide-react";
 
 export default function Projects() {
 
@@ -32,27 +32,40 @@ export default function Projects() {
               </p>
             </div>
 
-            <a
-              href={project.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-colors font-mono lowercase ${
-                project.isPrivate
-                  ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
-                  : "bg-red-500 text-white hover:bg-red-600"
-              }`}
-              title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
-            >
-              {project.isPrivate ? (
-                <>
-                  <Lock className="w-4 h-4" /> view repository
-                </>
-              ) : (
-                <>
-                  <ExternalLink className="w-4 h-4" /> view repository
-                </>
+            <div className="flex flex-col sm:flex-row gap-2">
+              {project.siteUrl && (
+                <a
+                  href={project.siteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-colors font-mono lowercase bg-blue-500 text-white hover:bg-blue-600"
+                  title="Visit Website"
+                >
+                  <Globe className="w-4 h-4" /> visit website
+                </a>
               )}
-            </a>
+              <a
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`inline-flex items-center gap-2 text-sm font-medium w-fit px-4 py-2 rounded-md transition-colors font-mono lowercase ${
+                  project.isPrivate
+                    ? "bg-destructive/10 text-destructive hover:bg-destructive/20 cursor-help"
+                    : "bg-red-500 text-white hover:bg-red-600"
+                }`}
+                title={project.isPrivate ? "Private Repository (only accessible with permission)" : "View Repository"}
+              >
+                {project.isPrivate ? (
+                  <>
+                    <Lock className="w-4 h-4" /> view repository
+                  </>
+                ) : (
+                  <>
+                    <ExternalLink className="w-4 h-4" /> view repository
+                  </>
+                )}
+              </a>
+            </div>
           </article>
         ))}
       </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -19,6 +19,7 @@ export const projects = [
     description: "a wealth tracker sitting at the top of the financial stack.",
     url: "https://github.com/vinersar31/capital",
     isPrivate: false,
+    siteUrl: "https://vinersar31.github.io/capital/",
   },
   {
     title: "vault",
@@ -47,6 +48,7 @@ export const projects = [
     description: "tracks the uptime of my ecosystem.",
     url: "https://github.com/vinersar31/sentinel",
     isPrivate: false,
+    siteUrl: "https://vinersar31.github.io/sentinel/",
   },
   {
     title: "eu compliance engine",
@@ -59,6 +61,7 @@ export const projects = [
     description: "an automated trading bot for cryptocurrency or stock markets.",
     url: "https://github.com/vinersar31/trading_bot",
     isPrivate: false,
+    siteUrl: "https://vinersar31.github.io/trading_bot/",
   },
   {
     title: "ai playground",


### PR DESCRIPTION
Added a conditional "visit website" button for projects that have a `siteUrl` defined. This links to the GitHub Pages site for specific projects like `capital`, `sentinel`, and `tradebot`.

- Updated `src/data/projects.ts` with `siteUrl` for applicable projects.
- Updated `src/app/projects/page.tsx` to render the button.
- Updated `tests/app/projects/page.test.tsx` to import the `Globe` icon so tests continue to pass.

---
*PR created automatically by Jules for task [13533799741399601721](https://jules.google.com/task/13533799741399601721) started by @vinersar31*